### PR TITLE
feat: Adds signature to Txclaim

### DIFF
--- a/node/api.proto
+++ b/node/api.proto
@@ -33,7 +33,11 @@ message Transaction {
   };
 
   // Block Claim collects a transaction from another account's block
-  message TxClaim { bytes transactionID = 1; };
+  message TxClaim { 
+    bytes transactionID = 1; 
+    bytes signature = 2;
+    bytes data = 3;
+  };
 
   // Block delegate assigns a new representative to an account
   message TxDelegate { bytes representative = 1; };


### PR DESCRIPTION
TxClaim needs a signature to validate that the user claiming, is the user specified by the Sender.

Co-authored-by: Arthlight <arthurpbh@gmail.com>